### PR TITLE
Corrected appleSingleTool options

### DIFF
--- a/Code/autopkglib/AbsoluteManageExport.py
+++ b/Code/autopkglib/AbsoluteManageExport.py
@@ -76,7 +76,7 @@ class AbsoluteManageExport(Processor):
                 self.output("[+] Failed to create [%s] Please check your permissions and try again. Error [%s]"  (dest_dir, err))
 
         try:
-            subprocess.check_output([self.appleSingleTool, "encode", "-s", source_dir, "-t", dest_dir + "/Payloads/" + self.unique_id])
+            subprocess.check_output([self.appleSingleTool, "encode", "-s", source_dir, "-t", dest_dir + "/Payloads/" + self.unique_id, "-p", "-x", "-z", "3"])
 
         except (subprocess.CalledProcessError, OSError), err:
             raise err


### PR DESCRIPTION
Martin mentioned that these are the correct options to use with the appleSingleTool from Absolute. While yours work, I believe the additional options are what should be used if Martin says so.